### PR TITLE
Fix compile errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 calling_from_make:
 	mix compile
 
-.PHONY: all libnifvec clean
+.PHONY: all libnif clean
 
 all: $(BUILD) $(PREFIX) $(PREFIX)/libnif.so
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Pelemay.MixProject do
       app: :pelemay,
       version: "0.0.1",
       elixir: "~> 1.9",
-      compilers: [:elixir_make | Mix.compilers()],
+      compilers: Mix.compilers() ++ [:elixir_make],
       make_targets: ["all"],
       make_clean: ["clean"],
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This PR fixed #13 .

The cause of error is NOT OTP version.
I checked for running `mix bench` in OTP 22.0.4.

This issue was occured #8 .
Need to run make command after unfolded elixir macro, because it generate native/lib.c.

So, I rearranged compilers_options in mix.exs. 
