### PR TITLE
Fixed the way to read basic.c to be used as a library.

### DIFF
--- a/lib/pelemay/generator/native.ex
+++ b/lib/pelemay/generator/native.ex
@@ -122,8 +122,7 @@ defmodule Pelemay.Generator.Native do
   end
 
   defp basic(str) do
-    current_dir = __ENV__.file |> :filename.dirname()
-    {:ok, ret} = File.read(current_dir <> "/native/basic.c")
+    {:ok, ret} = File.read(__DIR__ <> "/native/basic.c")
 
     str <> ret
   end

--- a/lib/pelemay/generator/native.ex
+++ b/lib/pelemay/generator/native.ex
@@ -3,8 +3,7 @@ defmodule Pelemay.Generator.Native do
 
   @nif_c "native/lib.c"
   @nif_module "PelemayNif"
-  @dir "lib/pelemay/generator/native/"
-  @deps_dir "deps/pelemay/"
+#  @dir "lib/pelemay/generator/native/"
 
   def generate do
     File.mkdir("native")
@@ -123,12 +122,10 @@ defmodule Pelemay.Generator.Native do
   end
 
   defp basic(str) do
-    case File.read(@dir <> "basic.c") do
-      {:ok, ret} -> str <> ret
-      {:error, :enoent} -> 
-        {:ok, ret} = File.read(@deps_dir <> @dir <> "basic.c")
-        str <> ret
-    end
+    current_dir = __ENV__.file |> :filename.dirname()
+    {:ok, ret} = File.read(current_dir <> "/native/basic.c")
+
+    str <> ret
   end
 
   # defp arithmetic(str) do

--- a/lib/pelemay/generator/native.ex
+++ b/lib/pelemay/generator/native.ex
@@ -4,6 +4,7 @@ defmodule Pelemay.Generator.Native do
   @nif_c "native/lib.c"
   @nif_module "PelemayNif"
   @dir "lib/pelemay/generator/native/"
+  @deps_dir "deps/pelemay/"
 
   def generate do
     File.mkdir("native")
@@ -122,9 +123,12 @@ defmodule Pelemay.Generator.Native do
   end
 
   defp basic(str) do
-    {:ok, ret} = File.read(@dir <> "basic.c")
-
-    str <> ret
+    case File.read(@dir <> "basic.c") do
+      {:ok, ret} -> str <> ret
+      {:error, :enoent} -> 
+        {:ok, ret} = File.read(@deps_dir <> @dir <> "basic.c")
+        str <> ret
+    end
   end
 
   # defp arithmetic(str) do


### PR DESCRIPTION
# Fixed the way to read basic.c to solve the not found error.
## Issue corresponding to
fixes #24 

## basic design

* read from lib/pelemay/generator/native/ first
* read again from deps/pelemay/lib/pelemay/generator/native/ when failed

## How to confirm

* add {:pelemay, "~> 0.0.1"} in mix.exs
* use deppelemay in the app
* compile it 

## Checklist

* [ ] Pelemay itself works
* [ ] app with Pelemay works

## Comment
* I am not sure the policy to use the attribute.
* There might be the better way to change the path.