### PR TITLE
Fixed the typo in config.yml.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,5 +29,5 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - <<: *install_hex_rebar 
       - run: mix deps.get
-      - run: mix fotrmat --check-formatted
+      - run: mix format --check-formatted
       - run: mix test


### PR DESCRIPTION
# Typo is in the config.yml
## Issue 

No issue is related to this.

## Design

* `fotrmat` -> `format`

## How to run

* Just build circleci

## Checklist

* [ ] mix format works (although it fails).

##  Something else
