### PR TITLE
make Pelemay the docs index

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,11 @@ defmodule Pelemay.MixProject do
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
-      deps: deps()
+      deps: deps(),
+      docs: [
+        api_reference: false,
+        main: "Pelemay"
+      ]
     ]
   end
 


### PR DESCRIPTION
This removes the api-reference page and makes the Pelemay module in the index for docs.

Fixes: #62 