### PR TITLE
Support String.replace (Part 1)

### DIFF
--- a/lib/pelemay/generator/interface.ex
+++ b/lib/pelemay/generator/interface.ex
@@ -54,9 +54,7 @@ defmodule Pelemay.Generator.Interface do
       nif_name: nif_name,
       module: _,
       function: _,
-      arg_num: num,
-      args: _,
-      operators: _
+      arg_num: num
     } = func_info
 
     args = generate_string_arguments(num)

--- a/lib/pelemay/generator/native.ex
+++ b/lib/pelemay/generator/native.ex
@@ -26,6 +26,8 @@ defmodule Pelemay.Generator.Native do
       code_info
       |> Enum.map(&generate_function(&1))
 
+    Db.get_functions()
+
     str <> Util.to_str_code(definition_func) <> func_list()
   end
 

--- a/lib/pelemay/generator/native/basic.c
+++ b/lib/pelemay/generator/native/basic.c
@@ -334,8 +334,13 @@ int string_replace_binary(ErlNifBinary subject, ErlNifBinary pattern, ErlNifBina
     while(subject_i < subject.size && subject.data[subject_i] != pattern.data[0]) {
       object->data[object_i++] = subject.data[subject_i++];
     }
+    if(__builtin_expect(subject_i >= subject.size, false)) {
+      return true;
+    }
     unsigned pattern_i = 0;
-    while(pattern_i < pattern.size && subject.data[subject_i + pattern_i] == pattern.data[pattern_i]) {
+    while(subject_i + pattern_i < subject.size
+      && pattern_i < pattern.size 
+      && subject.data[subject_i + pattern_i] == pattern.data[pattern_i]) {
       pattern_i++;
     }
     if(__builtin_expect(pattern_i == pattern.size, true)) {
@@ -354,6 +359,10 @@ int string_replace_binary(ErlNifBinary subject, ErlNifBinary pattern, ErlNifBina
         }
         return true;
       }
+    } else if(__builtin_expect(subject_i < subject.size, true)) {
+      object->data[object_i++] = subject.data[subject_i++];
+    } else {
+      return true;
     }
   }
   return true;

--- a/lib/pelemay/generator/native/basic.c
+++ b/lib/pelemay/generator/native/basic.c
@@ -323,3 +323,62 @@ enif_get_range(ErlNifEnv *env, ERL_NIF_TERM map, ErlNifSInt64 *from, ErlNifSInt6
   return success;
 }
 
+int string_replace_binary(ErlNifBinary subject, ErlNifBinary pattern, ErlNifBinary replacement, bool global, ErlNifBinary *object)
+{
+  if(__builtin_expect(!enif_alloc_binary(subject.size, object), false)) {
+    return false;
+  }
+  unsigned subject_i = 0, object_i = 0;
+#pragma clang loop vectorize_width(loop_vectorize_width)
+  while(subject_i < subject.size) {
+    while(subject_i < subject.size && subject.data[subject_i] != pattern.data[0]) {
+      object->data[object_i++] = subject.data[subject_i++];
+    }
+    unsigned pattern_i = 0;
+    while(pattern_i < pattern.size && subject.data[subject_i + pattern_i] == pattern.data[pattern_i]) {
+      pattern_i++;
+    }
+    if(__builtin_expect(pattern_i == pattern.size, true)) {
+      if(__builtin_expect(pattern.size != replacement.size, false)) {
+        if(__builtin_expect(!enif_realloc_binary(object, object->size - pattern.size + replacement.size), false)) {
+          return false;
+        }
+      }
+      subject_i += pattern.size;
+      for(unsigned replacement_i = 0; replacement_i < replacement.size; replacement_i++) {
+        object->data[object_i++] = replacement.data[replacement_i];
+      }
+      if(__builtin_expect(!global, false)) {
+        while(subject_i < subject.size) {
+          object->data[object_i++] = subject.data[subject_i++];
+        }
+        return true;
+      }
+    }
+  }
+  return true;
+}
+
+ERL_NIF_TERM string_replace(ErlNifEnv *env, ERL_NIF_TERM subject, ERL_NIF_TERM pattern, ERL_NIF_TERM replacement, bool global)
+{
+  ErlNifBinary subject_binary;
+  if(__builtin_expect(!enif_inspect_binary(env, subject, &subject_binary), false)) {
+    return enif_make_badarg(env);
+  }
+  ErlNifBinary pattern_binary;
+  if(__builtin_expect(!enif_inspect_binary(env, pattern, &pattern_binary), false)) {
+    return enif_make_badarg(env);
+  }
+  ErlNifBinary replacement_binary;
+  if(__builtin_expect(!enif_inspect_binary(env, replacement, &replacement_binary), false)) {
+    return enif_make_badarg(env);
+  }
+  ErlNifBinary object_binary;
+  if(__builtin_expect(!string_replace_binary(subject_binary, pattern_binary, replacement_binary, global, &object_binary), false)) {
+    return enif_make_badarg(env);
+  }
+  return enif_make_binary(env, &object_binary);
+}
+
+
+

--- a/lib/pelemay/generator/native/enum.ex
+++ b/lib/pelemay/generator/native/enum.ex
@@ -2,7 +2,17 @@ defmodule Pelemay.Generator.Native.Enum do
   alias Pelemay.Generator.Native.Util, as: Util
   alias Pelemay.Db
 
-  def map(%{nif_name: nif_name, args: args, operators: operators} = info) do
+  def map(info) do
+    %{
+      nif_name: nif_name,
+      args: [
+        func: %{
+          args: args,
+          operators: operators
+        }
+      ]
+    } = info
+
     expr_d = Util.make_expr(operators, args, "double")
     expr_l = Util.make_expr(operators, args, "long")
 
@@ -43,8 +53,7 @@ defmodule Pelemay.Generator.Native.Enum do
       module: _,
       function: _,
       arg_num: _,
-      args: _,
-      operators: _
+      args: _
     } = info
 
     {:ok, ret} = File.read(__DIR__ <> "/enum.c")

--- a/lib/pelemay/generator/native/string.ex
+++ b/lib/pelemay/generator/native/string.ex
@@ -1,6 +1,31 @@
 defmodule Pelemay.Generator.Native.String do
   alias Pelemay.Generator.Native.Util, as: Util
 
-  def replace(%{nif_name: nif_name, args: args, operators: operators}) do
+  def replace(info) do
+    %{
+      nif_name: nif_name,
+      module: _,
+      function: _,
+      arg_num: _,
+      args: args
+    } = info
+
+    info
+    |> Map.update(:arg_num, nil, fn _ -> 3 end)
+    |> Util.push_impl_info(true)
+
+    args |> Keyword.get_values(:var)
+
+    """
+    static
+    ERL_NIF_TERM #{nif_name}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+    {
+      if(__builtin_expect(argc != 3, false)) {
+        return enif_make_badarg(env);
+      }
+      bool global = true;
+      return string_replace(env, argv[0], argv[1], argv[2], global);
+    }
+    """
   end
 end

--- a/lib/pelemay/optimizer.ex
+++ b/lib/pelemay/optimizer.ex
@@ -148,21 +148,23 @@ defmodule Optimizer do
 
   def parallelize_term(term, {:Enum, true}) do
     info = SumMag.include_specified_functions?(term, :Enum, Enum.__info__(:functions))
-    Optimizer.init(term, info)
+    init(term, Enum: info)
   end
 
   def parallelize_term(term, {:String, true}) do
     info = SumMag.include_specified_functions?(term, :String, String.__info__(:functions))
-    Optimizer.init(term, info)
+
+    init(term, String: info)
   end
 
   def parallelize_term(term, _), do: term
 
-  def init(ast, []), do: ast
+  # @spec init(Macro.t(), list) :: 
+  def init(ast, [{_, []}]), do: ast
 
-  def init(ast, info) do
-    {_func, _meta, arg_func} = ast
-    optimized_ast = parallelize(info, arg_func)
+  def init(ast, module_info) do
+    {_func, _meta, args} = ast
+    optimized_ast = parallelize(module_info, args)
 
     case optimized_ast do
       {:ok, opt_ast} -> {ast, opt_ast}
@@ -170,19 +172,19 @@ defmodule Optimizer do
     end
   end
 
-  defp parallelize([{key, arity}], func) do
-    res = Analyzer.supported?(func)
-
-    call_nif(res, key, arity)
+  defp parallelize(module_info, args) do
+    Analyzer.supported?(args)
+    |> verify
+    |> case do
+      {:ok, polymap} -> {:ok, call_nif(polymap, module_info)}
+      {:error, _} -> {:error, "Not supported"}
+    end
   end
 
-  defp call_nif({:ok, asm}, key, arity) do
-    %{
-      operators: operators,
-      args: args
-    } = asm
+  defp call_nif(polymap, module_info) do
+    [{module, [{key, num}]}] = module_info
 
-    func_name = Optimizer.AFunction.generate_function_name(key, asm)
+    func_name = Optimizer.AFunction.generate_function_name(key, polymap)
 
     case Db.validate(func_name) do
       false ->
@@ -190,35 +192,50 @@ defmodule Optimizer do
 
       _ ->
         info = %{
-          module: :Enum,
+          module: module,
           function: key,
           nif_name: func_name,
-          arg_num: arity,
-          args: args,
-          operators: operators,
+          arg_num: 1,
+          args: polymap,
           impl: nil
         }
 
         Db.register(info)
     end
 
-    func_name = func_name |> String.to_atom()
-
-    ast =
-      case operators do
-        [] ->
-          quote do
-            ReplaceModule.unquote(func_name)(unquote(hd(args)))
-          end
-
-        other ->
-          quote do
-            ReplaceModule.unquote(func_name)
-          end
-      end
-
-    {:ok, ast}
+    replcae_function(func_name, polymap)
   end
 
-  defp call_nif({:error, asm}, key, _), do: {:error, "Not Supported"}
+  def replcae_function(func_name, polymap) do
+    func_name = func_name |> String.to_atom()
+
+    flat_vars =
+      polymap
+      |> Keyword.get_values(:var)
+      |> List.flatten()
+
+    {
+      {:., [], [{:__aliases__, [alias: false], [:ReplaceModule]}, func_name]},
+      [],
+      flat_vars
+    }
+  end
+
+  defp verify(polymap) when is_list(polymap) do
+    var_num =
+      polymap
+      |> Keyword.get_values(:var)
+      |> length
+
+    func_num =
+      polymap
+      |> Keyword.get_values(:func)
+      |> length
+
+    case {var_num, func_num} do
+      {0, 1} -> {:ok, polymap}
+      {0, 0} -> {:error, polymap}
+      {_, 0} -> {:ok, polymap}
+    end
+  end
 end

--- a/lib/pelemay/optimizer.ex
+++ b/lib/pelemay/optimizer.ex
@@ -173,7 +173,7 @@ defmodule Optimizer do
   end
 
   defp parallelize(module_info, args) do
-    Analyzer.supported?(args)
+    Analyzer.to_keyword(args)
     |> verify
     |> case do
       {:ok, polymap} -> {:ok, call_nif(polymap, module_info)}
@@ -182,7 +182,7 @@ defmodule Optimizer do
   end
 
   defp call_nif(polymap, module_info) do
-    [{module, [{key, num}]}] = module_info
+    [{module, [{key, _num}]}] = module_info
 
     func_name = Optimizer.AFunction.generate_function_name(key, polymap)
 
@@ -211,8 +211,8 @@ defmodule Optimizer do
 
     flat_vars =
       polymap
-      |> Keyword.get_values(:var)
       |> List.flatten()
+      |> Keyword.get_values(:var)
 
     {
       {:., [], [{:__aliases__, [alias: false], [:ReplaceModule]}, func_name]},
@@ -224,11 +224,13 @@ defmodule Optimizer do
   defp verify(polymap) when is_list(polymap) do
     var_num =
       polymap
+      |> List.flatten()
       |> Keyword.get_values(:var)
       |> length
 
     func_num =
       polymap
+      |> List.flatten()
       |> Keyword.get_values(:func)
       |> length
 
@@ -236,6 +238,7 @@ defmodule Optimizer do
       {0, 1} -> {:ok, polymap}
       {0, 0} -> {:error, polymap}
       {_, 0} -> {:ok, polymap}
+      _ -> {:error, polymap}
     end
   end
 end

--- a/lib/pelemay/optimizer/anonymous_function.ex
+++ b/lib/pelemay/optimizer/anonymous_function.ex
@@ -3,7 +3,9 @@ defmodule Optimizer.AFunction do
       when is_list(polymap) do
     ret =
       polymap
-      |> Enum.reduce("", fn {_, x}, acc -> acc <> "_" <> generate_function_name(x) end)
+      |> Enum.reduce("", fn {_, x}, acc ->
+        acc <> "_" <> generate_function_name(x)
+      end)
 
     Atom.to_string(func) <> ret
   end

--- a/lib/pelemay/optimizer/anonymous_function.ex
+++ b/lib/pelemay/optimizer/anonymous_function.ex
@@ -1,25 +1,33 @@
 defmodule Optimizer.AFunction do
-  def generate_function_name(func, %{args: args, operators: operators})
-      when is_atom(func) do
-    fun = fn
-      {:&, _meta, [num]} -> "elem#{num}"
-      {var, _, nil} -> Atom.to_string(var)
-      other -> "#{other}"
-    end
-
-    [h | args] = Enum.map(args, &fun.(&1))
-
-    expr =
-      operators
-      |> Enum.map(&Analyzer.operator_to_string(&1))
-      |> Enum.zip(args)
-
+  def generate_function_name(func, polymap)
+      when is_list(polymap) do
     ret =
-      expr
-      |> Enum.reduce(h, fn {op, arg}, acc -> acc <> "_#{op}_#{arg}" end)
+      polymap
+      |> Enum.reduce("", fn {_, x}, acc -> acc <> "_" <> generate_function_name(x) end)
 
-    func_name = Atom.to_string(func) <> "_"
-
-    func_name <> ret
+    Atom.to_string(func) <> ret
   end
+
+  def generate_function_name({:&, _meta, [num]}) do
+    "elem#{num}"
+  end
+
+  def generate_function_name({var, _, nil}) do
+    Atom.to_string(var)
+  end
+
+  def generate_function_name({:@, _, [{var, _, nil}]}) do
+    Atom.to_string(var) |> String.upcase()
+  end
+
+  def generate_function_name(%{args: args, operators: operators}) do
+    [h | string_args] = Enum.map(args, &generate_function_name(&1))
+
+    operators
+    |> Enum.map(&Analyzer.operator_to_string(&1))
+    |> Enum.zip(string_args)
+    |> Enum.reduce(h, fn {op, arg}, acc -> acc <> "_#{op}_#{arg}" end)
+  end
+
+  def generate_function_name(other), do: "#{other}"
 end

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -10,8 +10,10 @@ defmodule AnalyzerTest do
 
       assert {:|>, [context: _, import: Kernel], [[1, 2, 3], right]} = quoted
       assert {_enum_map, [], anonymous_function} = right
-      assert {:ok, info} = @subject.supported?(anonymous_function)
-      assert %{args: [{:x, [], AnalyzerTest}, 1], operators: [:+]} == info
+      assert [func: 
+        %{
+          args: [{:x, [], AnalyzerTest}, 1], 
+          operators: [:+]}] == @subject.supported?(anonymous_function)
     end
 
     test "with pipe, anonymous function: fn, two arguments" do
@@ -19,32 +21,32 @@ defmodule AnalyzerTest do
 
       assert {:|>, [context: _, import: Kernel], [[1, 2, 3], right]} = quoted
       assert {_enum_map, [], anonymous_function} = right
-      assert {:ok, info} = @subject.supported?(anonymous_function)
 
-      assert %{
+      assert  [func:  
+            %{
                args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
                operators: [:+, :+]
-             } == info
+             }] == @subject.supported?(anonymous_function)
     end
 
     test "with anonymous function: fn, one argument" do
       quoted = quote do: Enum.map([1, 2, 3], fn x -> x + 1 end)
 
       assert {_enum_map, [], [[1, 2, 3], anonymous_function]} = quoted
-      assert {:ok, info} = @subject.supported?(anonymous_function)
-      assert %{args: [{:x, [], AnalyzerTest}, 1], operators: [:+]} == info
+      assert [func: %{
+        args: [{:x, [], AnalyzerTest}, 1], 
+        operators: [:+]
+      }] == @subject.supported?(anonymous_function)
     end
 
     test "with anonymous function: fn, two arguments" do
       quoted = quote do: Enum.map([1, 2, 3], fn x, y -> x + y + 1 end)
 
       assert {_enum_map, [], [[1, 2, 3], anonymous_function]} = quoted
-      assert {:ok, info} = @subject.supported?(anonymous_function)
-
-      assert %{
+      assert [func: %{
                args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
                operators: [:+, :+]
-             } == info
+             }] == @subject.supported?(anonymous_function)
     end
 
     test "with basic types w/o tuples" do
@@ -79,28 +81,28 @@ defmodule AnalyzerTest do
     test "with two terms and one plus operator" do
       expr = quote do: 1 + 2.0
 
-      assert @subject.polynomial_map(expr) == %{
+      assert [func: %{
                operators: [:+],
                args: [1, 2.0]
-             }
+             }] == @subject.polynomial_map(expr)
     end
 
     test "with two terms is composed of one number and one captured val, which chained by one plus operator" do
       expr = quote do: &1 + 2
 
-      assert @subject.polynomial_map(expr) == %{
+      assert [func: %{
                operators: [:+],
                args: [{:&, [], [1]}, 2]
-             }
+             }] == @subject.polynomial_map(expr)
     end
 
     test "with two terms is composed of one number and one parameter, which chained by one plus operator" do
       expr = quote do: x + 2
 
-      assert @subject.polynomial_map(expr) == %{
+      assert [func: %{
                operators: [:+],
                args: [{:x, [], AnalyzerTest}, 2]
-             }
+             }] == @subject.polynomial_map(expr)
     end
   end
 end

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -12,7 +12,7 @@ defmodule AnalyzerTest do
       assert {_enum_map, [], anonymous_function} = right
 
       assert [func: %{args: [{:x, [], AnalyzerTest}, 1], operators: [:+]}] ==
-               @subject.supported?(anonymous_function)
+               @subject.to_keyword(anonymous_function)
     end
 
     test "with pipe, anonymous function: fn, two arguments" do
@@ -26,7 +26,7 @@ defmodule AnalyzerTest do
                  args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
                  operators: [:+, :+]
                }
-             ] == @subject.supported?(anonymous_function)
+             ] == @subject.to_keyword(anonymous_function)
     end
 
     test "with anonymous function: fn, one argument" do
@@ -56,12 +56,12 @@ defmodule AnalyzerTest do
     end
 
     test "with basic types w/o tuples" do
-      assert {:error, 1} == @subject.supported?(1)
-      assert {:error, [1]} == @subject.supported?([1])
-      assert {:error, true} == @subject.supported?(true)
-      assert {:error, "1"} == @subject.supported?("1")
-      assert {:error, '1'} == @subject.supported?('1')
-      assert {:error, :a} == @subject.supported?(:a)
+      assert [var: 1] == @subject.to_keyword(1)
+      assert [var: [1]] == @subject.to_keyword([1])
+      assert [var: true] == @subject.to_keyword(true)
+      assert [var: "1"] == @subject.to_keyword("1")
+      assert [var: '1'] == @subject.to_keyword('1')
+      assert [var: :a] == @subject.to_keyword(:a)
     end
 
     test "with one-element-tuple" do
@@ -73,7 +73,7 @@ defmodule AnalyzerTest do
     test "with two-elements-tuple" do
       quoted = quote do: {1, 2}
 
-      assert {:error, quoted} == @subject.supported?(quoted)
+      assert [var: {1, 2}] == @subject.supported?(quoted)
     end
 
     test "with three-elements-tuple" do

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -10,10 +10,9 @@ defmodule AnalyzerTest do
 
       assert {:|>, [context: _, import: Kernel], [[1, 2, 3], right]} = quoted
       assert {_enum_map, [], anonymous_function} = right
-      assert [func: 
-        %{
-          args: [{:x, [], AnalyzerTest}, 1], 
-          operators: [:+]}] == @subject.supported?(anonymous_function)
+
+      assert [func: %{args: [{:x, [], AnalyzerTest}, 1], operators: [:+]}] ==
+               @subject.supported?(anonymous_function)
     end
 
     test "with pipe, anonymous function: fn, two arguments" do
@@ -22,31 +21,38 @@ defmodule AnalyzerTest do
       assert {:|>, [context: _, import: Kernel], [[1, 2, 3], right]} = quoted
       assert {_enum_map, [], anonymous_function} = right
 
-      assert  [func:  
-            %{
-               args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
-               operators: [:+, :+]
-             }] == @subject.supported?(anonymous_function)
+      assert [
+               func: %{
+                 args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
+                 operators: [:+, :+]
+               }
+             ] == @subject.supported?(anonymous_function)
     end
 
     test "with anonymous function: fn, one argument" do
       quoted = quote do: Enum.map([1, 2, 3], fn x -> x + 1 end)
 
       assert {_enum_map, [], [[1, 2, 3], anonymous_function]} = quoted
-      assert [func: %{
-        args: [{:x, [], AnalyzerTest}, 1], 
-        operators: [:+]
-      }] == @subject.supported?(anonymous_function)
+
+      assert [
+               func: %{
+                 args: [{:x, [], AnalyzerTest}, 1],
+                 operators: [:+]
+               }
+             ] == @subject.supported?(anonymous_function)
     end
 
     test "with anonymous function: fn, two arguments" do
       quoted = quote do: Enum.map([1, 2, 3], fn x, y -> x + y + 1 end)
 
       assert {_enum_map, [], [[1, 2, 3], anonymous_function]} = quoted
-      assert [func: %{
-               args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
-               operators: [:+, :+]
-             }] == @subject.supported?(anonymous_function)
+
+      assert [
+               func: %{
+                 args: [{:x, [], AnalyzerTest}, {:y, [], AnalyzerTest}, 1],
+                 operators: [:+, :+]
+               }
+             ] == @subject.supported?(anonymous_function)
     end
 
     test "with basic types w/o tuples" do
@@ -81,28 +87,34 @@ defmodule AnalyzerTest do
     test "with two terms and one plus operator" do
       expr = quote do: 1 + 2.0
 
-      assert [func: %{
-               operators: [:+],
-               args: [1, 2.0]
-             }] == @subject.polynomial_map(expr)
+      assert [
+               func: %{
+                 operators: [:+],
+                 args: [1, 2.0]
+               }
+             ] == @subject.polynomial_map(expr)
     end
 
     test "with two terms is composed of one number and one captured val, which chained by one plus operator" do
       expr = quote do: &1 + 2
 
-      assert [func: %{
-               operators: [:+],
-               args: [{:&, [], [1]}, 2]
-             }] == @subject.polynomial_map(expr)
+      assert [
+               func: %{
+                 operators: [:+],
+                 args: [{:&, [], [1]}, 2]
+               }
+             ] == @subject.polynomial_map(expr)
     end
 
     test "with two terms is composed of one number and one parameter, which chained by one plus operator" do
       expr = quote do: x + 2
 
-      assert [func: %{
-               operators: [:+],
-               args: [{:x, [], AnalyzerTest}, 2]
-             }] == @subject.polynomial_map(expr)
+      assert [
+               func: %{
+                 operators: [:+],
+                 args: [{:x, [], AnalyzerTest}, 2]
+               }
+             ] == @subject.polynomial_map(expr)
     end
   end
 end

--- a/test/generated_code_test.exs
+++ b/test/generated_code_test.exs
@@ -48,6 +48,11 @@ defmodule GeneratedCodeTest do
       assert "AAAA" == Sample.replace_sample_c1("aaaa")
       assert "AAAA" == Sample.replace_sample_c2("aaaa")
       assert "AAAA" == Sample.replace_sample_c3("aaaa", "a", "A")
+
+      assert """
+             abcdefghi
+             BuzzBuzzBuzzBuzz
+             """ == Sample.string_replace_c4()
     end
   end
 end

--- a/test/generated_code_test.exs
+++ b/test/generated_code_test.exs
@@ -42,4 +42,12 @@ defmodule GeneratedCodeTest do
       assert [{1, 3}, {2, 4}] == Sample.list_zip([1, 2], [3, 4])
     end
   end
+
+  describe "String module" do
+    test "replace/3" do
+      assert "AAAA" == Sample.replace_sample_c1("aaaa")
+      assert "AAAA" == Sample.replace_sample_c2("aaaa")
+      assert "AAAA" == Sample.replace_sample_c3("aaaa", "a", "A")
+    end
+  end
 end

--- a/test/support/sample.ex
+++ b/test/support/sample.ex
@@ -2,6 +2,10 @@ defmodule Sample do
   import Pelemay
   require Pelemay
 
+  @string """
+  abcdefghi
+  FizzBuzzFizzBuzz
+  """
   @pattern "a"
   @replacement "A"
 
@@ -57,6 +61,10 @@ defmodule Sample do
 
     def replace_sample_c3(subject, pattern, replacement) do
       String.replace(subject, pattern, replacement)
+    end
+
+    def string_replace_c4 do
+      String.replace(@string, "Fizz", "Buzz")
     end
   end
 end

--- a/test/support/sample.ex
+++ b/test/support/sample.ex
@@ -2,6 +2,9 @@ defmodule Sample do
   import Pelemay
   require Pelemay
 
+  @pattern "a"
+  @replacement "A"
+
   defpelemay do
     def list_square(list) when is_list(list) do
       list
@@ -42,6 +45,18 @@ defmodule Sample do
 
     def list_zip(a, b) do
       Enum.zip(a, b)
+    end
+
+    def replace_sample_c1(subject) do
+      String.replace(subject, @pattern, @replacement)
+    end
+
+    def replace_sample_c2(subject) do
+      subject |> String.replace(@pattern, @replacement)
+    end
+
+    def replace_sample_c3(subject, pattern, replacement) do
+      String.replace(subject, pattern, replacement)
     end
   end
 end


### PR DESCRIPTION
Support String.replace in the following cases using #98 and #99 

- [x] case1
- [x] case2

```elixir
defpelemay do
  def case_1 replace_sample subject do
    String.replace(subject, @pattern, @replacement)
  end

  def case_2 replace_sample subject do
    subject |> String.replace(@pattern, @replacement)
  end
end
```

where `@pattern` and `@replacement` are constant.

branch name is `string_replace`.