### PR TITLE
fix document rendering errors

### DIFF
--- a/lib/pelemay/generator.ex
+++ b/lib/pelemay/generator.ex
@@ -6,96 +6,96 @@ defmodule Pelemay.Generator do
   require Logger
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.module_replaced_non(:"Elixir.Module")
-    "ElixirModule"
-
+  ```
+  iex> Pelemay.Generator.module_replaced_non(:"Elixir.Module")
+  "ElixirModule"
+  ```
   """
   def module_replaced_non(module) do
     module |> Atom.to_string() |> String.replace(".", "")
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.module_replaced_underscore(:"Elixir.Module")
-    "Elixir_Module"
-    
+  ```
+  iex> Pelemay.Generator.module_replaced_underscore(:"Elixir.Module")
+  "Elixir_Module"
+  ```
   """
   def module_replaced_underscore(module) do
     module |> Atom.to_string() |> String.replace(".", "_")
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.nif_module(:"Elixir.Module")
-    "PelemayNifElixirModule"
-
+  ```
+  iex> Pelemay.Generator.nif_module(:"Elixir.Module")
+  "PelemayNifElixirModule"
+  ```
   """
   def nif_module(module) do
     "PelemayNif#{module_replaced_non(module)}"
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.elixir_nif_module(:"Elixir.Module")
-    "Elixir.PelemayNifElixirModule"
-    
+  ```
+  iex> Pelemay.Generator.elixir_nif_module(:"Elixir.Module")
+  "Elixir.PelemayNifElixirModule"
+  ```
   """
   def elixir_nif_module(module) do
     "Elixir.PelemayNif#{module_replaced_non(module)}"
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.module_downcase_non(:"Elixir.Module")
-    "elixirmodule"
-    
+  ```
+  iex> Pelemay.Generator.module_downcase_non(:"Elixir.Module")
+  "elixirmodule"
+  ```
   """
   def module_downcase_non(module) do
     module |> module_replaced_non() |> String.downcase()
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.module_downcase_underscore(:"Elixir.Module")
-    "elixir_module"
-    
+  ```
+  iex> Pelemay.Generator.module_downcase_underscore(:"Elixir.Module")
+  "elixir_module"
+  ```
   """
   def module_downcase_underscore(module) do
     module |> module_replaced_underscore() |> String.downcase()
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.libnif_name(:"Elixir.Module")
-    "libnifelixirmodule"
-    
+  ```
+  iex> Pelemay.Generator.libnif_name(:"Elixir.Module")
+  "libnifelixirmodule"
+  ```
   """
   def libnif_name(module) do
     "libnif#{module_downcase_non(module)}"
   end
 
   @doc """
-
   ## Examples
 
-    iex> Pelemay.Generator.libnif_priv_name(:"Elixir.Module")
-    "priv/libnifelixirmodule"
-    
+  ```
+  iex> Pelemay.Generator.libnif_priv_name(:"Elixir.Module")
+  "priv/libnifelixirmodule"
+  ```
   """
   def libnif_priv_name(module) do
     "priv/#{libnif_name(module)}"

--- a/lib/pelemay/generator/name.ex
+++ b/lib/pelemay/generator/name.ex
@@ -1,9 +1,11 @@
 defmodule Generator.Name do
   @doc """
+  ```
   iex> func_label = [[map: 1]]
   iex> polymap = [func: %{args: [{:&, [], [1]}, {:&, [], [1]}], operators: [:*]}]
   iex> Generator.Name.generate_function_name(func_label, polymap)
   "map_elem1_mult_elem1"
+  ```
   """
   def generate_function_name(functions, polymap)
       when is_list(functions) do

--- a/lib/sum_mag.ex
+++ b/lib/sum_mag.ex
@@ -6,20 +6,23 @@ defmodule SumMag do
   @type t :: Macro.t()
 
   @doc """
-      ## Examples
-      iex> quote do end |> SumMag.parse(%{target: :pelemay})
-      []
+  ## Examples
 
-      iex> (quote do: def func(a), do: a) |> SumMag.parse(%{target: :pelemay})
-      [[function_name: :func, is_public: true, args: [:a], do: [{:a, [], SumMagTest}], is_nif: false ]]
+  ```
+  iex> quote do end |> SumMag.parse(%{target: :pelemay})
+  []
 
-      iex> (quote do
-      ...>    def func(list) do
-      ...>      list
-      ...>      |> Enum.map(& &1)
-      ...>    end
-      ...> end) |> SumMag.parse(%{target: :pelemay})
-      [[function_name: :func, is_public: true, args: [:list], do: [{:|>, [context: SumMagTest, import: Kernel], [{:list, [], SumMagTest}, {{:., [], [{:__aliases__, [alias: false], [:Enum]}, :map]}, [], [{:&, [], [{:&, [], [1]}]}]}]}], is_nif: false ]]
+  iex> (quote do: def func(a), do: a) |> SumMag.parse(%{target: :pelemay})
+  [[function_name: :func, is_public: true, args: [:a], do: [{:a, [], SumMagTest}], is_nif: false ]]
+
+  iex> (quote do
+  ...>    def func(list) do
+  ...>      list
+  ...>      |> Enum.map(& &1)
+  ...>    end
+  ...> end) |> SumMag.parse(%{target: :pelemay})
+  [[function_name: :func, is_public: true, args: [:list], do: [{:|>, [context: SumMagTest, import: Kernel], [{:list, [], SumMagTest}, {{:., [], [{:__aliases__, [alias: false], [:Enum]}, :map]}, [], [{:&, [], [{:&, [], [1]}]}]}]}], is_nif: false ]]
+  ```
   """
   def parse({:__block__, _e, []}, _env), do: []
 
@@ -48,30 +51,34 @@ defmodule SumMag do
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> [{:null, [context: Elixir], []}, [do: {:nil, [], Elixir}]] |> SumMag.parse_function_name(%{})
-    :null
+  ```
+  iex> [{:null, [context: Elixir], []}, [do: {:nil, [], Elixir}]] |> SumMag.parse_function_name(%{})
+  :null
 
-    iex> [{:func, [context: Elixir], [{:a, [], Elixir}]}, [do: {:a, [], Elixir}]] |> SumMag.parse_function_name(%{})
-    :func
+  iex> [{:func, [context: Elixir], [{:a, [], Elixir}]}, [do: {:a, [], Elixir}]] |> SumMag.parse_function_name(%{})
+  :func
 
-    iex> [{:add, [context: Elixir], [{:a, [], Elixir}, {:b, [], Elixir}]},[do: {:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]] |> SumMag.parse_function_name(%{})
-    :add
+  iex> [{:add, [context: Elixir], [{:a, [], Elixir}, {:b, [], Elixir}]},[do: {:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]] |> SumMag.parse_function_name(%{})
+  :add
+  ```
   """
   def parse_function_name(body, _env), do: body |> hd |> elem(0)
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> [{:null, [context: Elixir], []}, [do: {:nil, [], Elixir}]] |> SumMag.parse_args(%{})
-    []
+  ```
+  iex> [{:null, [context: Elixir], []}, [do: {:nil, [], Elixir}]] |> SumMag.parse_args(%{})
+  []
 
-    iex> [{:func, [context: Elixir], [{:a, [], Elixir}]}, [do: {:a, [], Elixir}]] |> SumMag.parse_args(%{})
-    [:a]
+  iex> [{:func, [context: Elixir], [{:a, [], Elixir}]}, [do: {:a, [], Elixir}]] |> SumMag.parse_args(%{})
+  [:a]
 
-    iex> [{:add, [context: Elixir], [{:a, [], Elixir}, {:b, [], Elixir}]},[do: {:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]] |> SumMag.parse_args(%{})
-    [:a, :b]
+  iex> [{:add, [context: Elixir], [{:a, [], Elixir}, {:b, [], Elixir}]},[do: {:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]] |> SumMag.parse_args(%{})
+  [:a, :b]
+  ```
   """
   def parse_args(body, env) do
     body
@@ -81,30 +88,34 @@ defmodule SumMag do
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> [] |> SumMag.convert_args(%{})
-    []
+  ```
+  iex> [] |> SumMag.convert_args(%{})
+  []
 
-    iex> [{:a, [], Elixir}] |> SumMag.convert_args(%{})
-    [:a]
+  iex> [{:a, [], Elixir}] |> SumMag.convert_args(%{})
+  [:a]
 
-    iex> [{:a, [], Elixir}, {:b, [], Elixir}] |> SumMag.convert_args(%{})
-    [:a, :b]
+  iex> [{:a, [], Elixir}, {:b, [], Elixir}] |> SumMag.convert_args(%{})
+  [:a, :b]
+  ```
   """
   def convert_args(arg_list, _env), do: arg_list |> Enum.map(&elem(&1, 0))
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> [{:null, [context: Elixir], []}, [do: {:nil, [], Elixir}]] |> SumMag.parse_do(%{})
-    [{:nil, [], Elixir}]
+  ```
+  iex> [{:null, [context: Elixir], []}, [do: {:nil, [], Elixir}]] |> SumMag.parse_do(%{})
+  [{:nil, [], Elixir}]
 
-    iex> [{:func, [context: Elixir], [{:a, [], Elixir}]}, [do: {:a, [], Elixir}]] |> SumMag.parse_do(%{})
-    [{:a, [], Elixir}]
+  iex> [{:func, [context: Elixir], [{:a, [], Elixir}]}, [do: {:a, [], Elixir}]] |> SumMag.parse_do(%{})
+  [{:a, [], Elixir}]
 
-    iex> [{:add, [context: Elixir], [{:a, [], Elixir}, {:b, [], Elixir}]},[do: {:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]] |> SumMag.parse_do(%{})
-    [{:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]
+  iex> [{:add, [context: Elixir], [{:a, [], Elixir}, {:b, [], Elixir}]},[do: {:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]] |> SumMag.parse_do(%{})
+  [{:+, [context: Elixir, import: Kernel], [{:a, [], Elixir}, {:b, [], Elixir}]}]
+  ```
   """
   def parse_do(body, env) do
     body
@@ -130,74 +141,88 @@ defmodule SumMag do
   defp parse_do_body(value, _env), do: [value]
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> SumMag.increment_nif(%{num: 0})
-    1
+  ```
+  iex> SumMag.increment_nif(%{num: 0})
+  1
 
-    iex> SumMag.increment_nif(%{num: 1})
-    2
+  iex> SumMag.increment_nif(%{num: 1})
+  2
+  ```
   """
   def increment_nif(%{num: num}) do
     num + 1
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> :func |> SumMag.concat_name_num(%{num: 1})
-    :func_1
+  ```
+  iex> :func |> SumMag.concat_name_num(%{num: 1})
+  :func_1
 
-    iex> :fl |> SumMag.concat_name_num(%{num: 2})
-    :fl_2
+  iex> :fl |> SumMag.concat_name_num(%{num: 2})
+  :fl_2
+  ```
   """
   def concat_name_num(name, %{num: num}) do
     name |> Atom.to_string() |> Kernel.<>("_#{num}") |> String.to_atom()
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> :func |> SumMag.concat_name_nif(%{})
-    :func_nif
+  ```
+  iex> :func |> SumMag.concat_name_nif(%{})
+  :func_nif
+  ```
   """
   def concat_name_nif(name, _env) do
     name |> Atom.to_string() |> Kernel.<>("_nif") |> String.to_atom()
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> :pelemay |> SumMag.concat_name_stub(%{})
-    :pelemaystub
+  ```
+  iex> :pelemay |> SumMag.concat_name_stub(%{})
+  :pelemaystub
+  ```
   """
   def concat_name_stub(name, _env) do
     name |> Atom.to_string() |> Kernel.<>("stub") |> String.to_atom()
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> SumMag.func_with_num([function_name: :func], %{num: 1})
-    [function_name: :func_1]
+  ```
+  iex> SumMag.func_with_num([function_name: :func], %{num: 1})
+  [function_name: :func_1]
+  ```
   """
   def func_with_num(kl, env) do
     Keyword.put(kl, :function_name, kl[:function_name] |> SumMag.concat_name_num(env))
   end
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> SumMag.get_func_info(%{nif: [function_name: :func]})
-    [function_name: :func]
+  ```
+  iex> SumMag.get_func_info(%{nif: [function_name: :func]})
+  [function_name: :func]
+  ```
   """
   def get_func_info(%{nif: func_info}), do: func_info
 
   @doc """
-    ## Examples
+  ## Examples
 
-    iex> SumMag.merge_func_info(%{nif: [function_name: :func]}, [is_public: true])
-    %{nif: [function_name: :func, is_public: true]}
+  ```
+  iex> SumMag.merge_func_info(%{nif: [function_name: :func]}, [is_public: true])
+  %{nif: [function_name: :func, is_public: true]}
+  ```
   """
   def merge_func_info(env, keyword) do
     Map.put(env, :nif, Keyword.merge(get_func_info(env), keyword))
@@ -209,27 +234,27 @@ defmodule SumMag do
   If you define a function:
 
   ```
-  [ 
+  [
     do: {def, _line, [
       { :name, _line, arg },
       [
         do: main_process
       ]}
   ]
-  ```      
+  ```
 
   If you define functions:
   ```
-  [ 
+  [
     do: {:__block__, [], [
       {def, _line, [{ :name, _line, arg },do: main_process
       ]}
   ]
   ```
 
-        iex> quote do  
-        ...>   def func do: "doctest"    
-        ...> end  
+        iex> quote do
+        ...>   def func do: "doctest"
+        ...> end
         {:def, [context: SumMagTest, import: Kernel],
           [{:func, [context: SumMagTest], [[do: "doctest"]]}]}
 
@@ -237,8 +262,8 @@ defmodule SumMag do
         ...>   defmmf do
         ...>     def func do: "doctest"
         ...>   end
-        ...> end 
-        
+        ...> end
+
   """
   def melt_block(do: {:__block__, [], []}), do: []
   def melt_block(do: {:__block__, [], funcs}), do: funcs
@@ -273,7 +298,7 @@ defmodule SumMag do
 
   def quoted_vars?(left, right), do: quoted_var?(left) && quoted_var?(right)
 
-  # def include_func?(ast, module_name, func_list) 
+  # def include_func?(ast, module_name, func_list)
   #   when is_atom(module_name) and is_list(func_name) do
 
   # end


### PR DESCRIPTION
The documents of Pelemay have some rendering errors. I guess those rendering results are not what you wanted.

![image](https://user-images.githubusercontent.com/3458/101987881-f7545100-3cd9-11eb-9313-4742d9b169a7.png)
[SumMag — pelemay v0.0.14](https://hexdocs.pm/pelemay/SumMag.html#functions)

If you merge this pull request, you'll see the documents rendered as below:

![image](https://user-images.githubusercontent.com/3458/101988025-9d07c000-3cda-11eb-9672-d3255e682d9f.png)
