### PR TITLE
Remove unused function: SumMag.include_specified_functions/2

### DIFF
--- a/lib/sum_mag.ex
+++ b/lib/sum_mag.ex
@@ -370,33 +370,6 @@ defmodule SumMag do
     match
   end
 
-  def include_specified_functions(ast_term, module_functions) do
-    verify = fn
-      {{:., _, [{:__aliases__, _, [code_module]}, code_func]}, _, _args} = ast, acc ->
-        module_functions
-        |> Enum.map(fn {module, functions} ->
-          if code_module != module do
-            {ast, acc}
-          else
-            functions
-            |> Enum.map(fn {func, _arity} ->
-              case Keyword.fetch(func, code_func) do
-                {:ok, _} -> {ast, Keyword.update(acc, code_func, 1, &(&1 + 1))}
-                _ -> {ast, acc}
-              end
-            end)
-          end
-        end)
-
-      ast, acc ->
-        {ast, acc}
-    end
-
-    {_, match} = Macro.prewalk(ast_term, [], verify)
-
-    match
-  end
-
   @doc false
   def divide_meta(ast) do
     Macro.prewalk(ast, [], fn


### PR DESCRIPTION
It looks like this function is an unused duplicate of `SumMag.include_specified_functions?/2`