### PR TITLE
Resolve Dialyzer warnings

### DIFF
--- a/lib/pelemay/generator/builder.ex
+++ b/lib/pelemay/generator/builder.ex
@@ -413,7 +413,6 @@ defmodule Pelemay.Generator.Builder do
       {:unix, :darwin} -> @mac_error_msg
       {:unix, _} -> @unix_error_msg
       {:win32, _} -> @windows_error_msg
-      _ -> ""
     end
   end
 

--- a/lib/pelemay/logger.ex
+++ b/lib/pelemay/logger.ex
@@ -33,11 +33,7 @@ defmodule Pelemay.Logger do
         metadata
       )
 
-    File.write!(state.path, "#{log_line}\n", [:append])
-    |> case do
-      :ok -> nil
-      other -> Logger.warn("#{other}")
-    end
+    :ok = File.write!(state.path, "#{log_line}\n", [:append])
 
     {:ok, state}
   end

--- a/lib/sum_mag.ex
+++ b/lib/sum_mag.ex
@@ -348,7 +348,8 @@ defmodule SumMag do
   [map: 2]
   ```
   """
-  @spec include_specified_functions?(Macro.input(), [{atom, list}]) :: [...]
+  @spec include_specified_functions?(Macro.input(), [{atom, list}]) ::
+          Keyword.t(non_neg_integer())
   def include_specified_functions?(ast_term, [{module, func}]) do
     verify = fn
       {{:., _, [{:__aliases__, _, [code_module]}, code_func]}, _, _args} = ast, acc ->


### PR DESCRIPTION
There was three warnings from Dialyzer.

1) A redundant case clause when matching against `File.read!/3`: https://github.com/zeam-vm/pelemay/compare/master...QuinnWilton:quinn/dialyzer?expand=1#diff-4972a9be985f9b913c07209d94d51a2388f542f91879b0f5983ddf8179b4a06bL36

2) A redundant case clause when matching against `:os.type/0`: https://github.com/zeam-vm/pelemay/compare/master...QuinnWilton:quinn/dialyzer?expand=1#diff-207e0d18a388a2190dea937d097735e2a0edc66008b2594f7d3bc798515790bfL416

3) An incorrect return type: https://github.com/zeam-vm/pelemay/compare/master...QuinnWilton:quinn/dialyzer?expand=1#diff-d0637b531f44050d0caee09480539649b69f5bbfed921ce18867be1c5623b472L351